### PR TITLE
edtlib: add maps property tests

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1322,6 +1322,90 @@ class Node:
         return res
 
     @property
+    def maps(self) -> list[ControllerAndData]:
+        res: list[ControllerAndData] = []
+
+        def count_cells_num(node: dtlib_Node, specifier: str) -> int:
+            """Calculate the number of cells in *node* for *specifier*."""
+
+            if node is None:
+                _err("node is None.")
+
+            num = node.props[f"#{specifier}-cells"].to_num()
+
+            if specifier == "interrupt":
+                parent_props = None
+                if node.parent:
+                    parent_props = node.parent.props
+
+                if "#address-cells" in node.props:
+                    num += node.props["#address-cells"].to_num()
+                elif parent_props and "#address-cells" in parent_props:
+                    num += parent_props["#address-cells"].to_num()
+                else:
+                    _err("Neither the node nor its parent has `#address-cells` property")
+
+            return num
+
+        for prop in [v for k, v in self._node.props.items() if k.endswith("-map")]:
+            specifier_space = prop.name[:-4]  # Strip '-map'
+            raw = prop.value
+            while raw:
+                if len(raw) < 4:
+                    # Not enough room for phandle
+                    _err("bad value for " + repr(prop))
+
+                child_specifier_num = count_cells_num(prop.node, specifier_space)
+
+                child_specifiers = to_nums(raw[: 4 * child_specifier_num])
+                raw = raw[4 * child_specifier_num :]
+                phandle = to_num(raw[:4])
+                raw = raw[4:]
+
+                controller_node = prop.node.dt.phandle2node.get(phandle)
+                if controller_node is None:
+                    _err(f"controller node cannot be found from phandle:{phandle}")
+
+                controller: Node = self.edt._node2enode[controller_node]
+                if controller is None:
+                    _err("controller cannot be found from: " + repr(controller_node))
+
+                parent_specifier_num = count_cells_num(controller_node, specifier_space)
+                parent_specifiers = to_nums(raw[: 4 * parent_specifier_num])
+                raw = raw[4 * parent_specifier_num :]
+
+                values: dict[str, int] = {}
+                for i, val in enumerate(child_specifiers):
+                    cell_name = f"child_specifier_{i}"
+                    if (
+                        self._binding
+                        and self._binding.specifier2cells
+                        and specifier_space in self._binding.specifier2cells
+                        and i < len(self._binding.specifier2cells[specifier_space])
+                    ):
+                        cell_name = self._binding.specifier2cells[specifier_space][i]
+
+                    values[cell_name] = val
+
+                for i, val in enumerate(parent_specifiers):
+                    values[f"parent_specifier_{i}"] = val
+
+                res.append(
+                    ControllerAndData(
+                        node=self,
+                        controller=controller,
+                        data=values,
+                        name=None,
+                        basename=specifier_space,
+                    )
+                )
+
+            if len(raw) != 0:
+                _err(f"unexpected prop.value remainings: {raw}")
+
+        return res
+
+    @property
     def has_child_binding(self) -> bool:
         """
         True if the node's binding contains a child-binding definition, False

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -130,6 +130,45 @@ def test_interrupts():
         edtlib.ControllerAndData(node=node, controller=edt.get_node('/interrupt-map-bitops-test/controller'), data={'one': 3, 'two': 2}, name=None, basename=None)
     ]
 
+
+def test_maps():
+    '''Tests for the maps property.'''
+
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    def expected(node, controller, child_specifiers, parent_specifiers, basename):
+        values = {f"child_specifier_{i}": val for i, val in enumerate(child_specifiers)}
+        values.update({f"parent_specifier_{i}": val for i, val in enumerate(parent_specifiers)})
+        return edtlib.ControllerAndData(
+            node=node,
+            controller=controller,
+            data=values,
+            name=None,
+            basename=basename,
+        )
+
+    connector = edt.get_node("/gpio-map/connector")
+    destination = edt.get_node("/gpio-map/destination")
+    assert connector.maps == [
+        expected(connector, destination, [1, 2], [5], "gpio"),
+        expected(connector, destination, [3, 4], [6], "gpio"),
+    ]
+
+    nexus = edt.get_node("/interrupt-map-test/nexus")
+    controller_0 = edt.get_node('/interrupt-map-test/controller-0')
+    controller_1 = edt.get_node('/interrupt-map-test/controller-1')
+    controller_2 = edt.get_node('/interrupt-map-test/controller-2')
+    assert nexus.maps == [
+        expected(nexus, controller_0, [0, 0, 0, 0], [0, 0], "interrupt"),
+        expected(nexus, controller_1, [0, 0, 0, 1], [0, 0, 0, 1], "interrupt"),
+        expected(nexus, controller_2, [0, 0, 0, 2], [0, 0, 0, 0, 0, 2], "interrupt"),
+        expected(nexus, controller_0, [0, 1, 0, 0], [0, 3], "interrupt"),
+        expected(nexus, controller_1, [0, 1, 0, 1], [0, 0, 0, 4], "interrupt"),
+        expected(nexus, controller_2, [0, 1, 0, 2], [0, 0, 0, 0, 0, 5], "interrupt"),
+    ]
+
+
 def test_ranges():
     '''Tests for the ranges property'''
     with from_here():


### PR DESCRIPTION
## Summary
- add a Node.maps property to expose parsed *-map relationships as ControllerAndData objects
- extend the edtlib unit test suite to cover gpio-map and interrupt-map handling

## Testing
- `PYTHONPATH=scripts/dts/python-devicetree/src pytest scripts/dts/python-devicetree/tests/test_edtlib.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce20b3dad483228bbc2b05740a4c75