### PR TITLE
Fix htiled glyph byte indexing

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -77,10 +77,12 @@ static inline uint8_t get_glyph_byte(uint8_t *glyph_ptr, const struct cfb_font *
 				     uint8_t x, uint8_t y, bool vtiled)
 {
 	if (fptr->caps & CFB_FONT_MONO_VPACKED) {
+		const size_t bytes_per_column = DIV_ROUND_UP(fptr->height, 8U);
+
 		if (vtiled) {
-			return glyph_ptr[x * DIV_ROUND_UP(fptr->height, 8U) + y];
+			return glyph_ptr[x * bytes_per_column + y];
 		} else {
-			return glyph_ptr[(x * fptr->height + y) / 8];
+			return glyph_ptr[x * bytes_per_column + (y / 8U)];
 		}
 	} else if (fptr->caps & CFB_FONT_MONO_HPACKED) {
 		return glyph_ptr[y * (fptr->width) + x];


### PR DESCRIPTION
## Summary
- reuse the vertical tile byte count when accessing mono-vpacked glyph data
- correct the htiled path to select the right byte within each column

## Testing
- `west twister --emulation-only -p native_sim/native/64 -X display -j 1 -T tests/subsys/display/cfb/basic/`


------
https://chatgpt.com/codex/tasks/task_e_68d13a42bdd48322b8bb82295c43b48f