### PR TITLE
doc: annotate virtio config entries

### DIFF
--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -27,24 +27,33 @@ extern "C" {
  */
 
 /**
- * Callback used during virtqueue enumeration
+ * @brief Callback used during virtqueue discovery.
  *
- * @param queue_idx index of currently inspected queue
- * @param max_queue_size maximum permitted size of currently inspected queue
- * @param opaque pointer to user provided data
- * @return the size of currently inspected virtqueue we want to set
+ * The callback mirrors the queue sizing step required by Virtio 1.3,
+ * §3.1 "Device Initialization", where the driver probes each
+ * virtqueue exposed by the transport specific configuration.
+ *
+ * @param queue_idx Index of the currently inspected queue.
+ * @param max_queue_size Maximum permitted size of the queue as reported by
+ *                       the transport.
+ * @param opaque Pointer to user provided data.
+ * @return The virtqueue size that should be programmed for @p queue_idx.
  */
 typedef uint16_t (*virtio_enumerate_queues)(
-	uint16_t queue_idx, uint16_t max_queue_size, void *opaque
+        uint16_t queue_idx, uint16_t max_queue_size, void *opaque
 );
 
 /**
- * @brief Virtio api structure
+ * @brief Virtio driver API contract.
+ *
+ * The entry points correspond to the generic initialization and
+ * operation flow described in Virtio 1.3, Chapter 3 "General
+ * Initialization And Device Operation".
  */
 __subsystem struct virtio_driver_api {
-	struct virtq *(*get_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void (*notify_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void *(*get_device_specific_config)(const struct device *dev);
+        struct virtq *(*get_virtqueue)(const struct device *dev, uint16_t queue_idx);
+        void (*notify_virtqueue)(const struct device *dev, uint16_t queue_idx);
+        void *(*get_device_specific_config)(const struct device *dev);
 	bool (*read_device_feature_bit)(const struct device *dev, int bit);
 	int (*write_driver_feature_bit)(const struct device *dev, int bit, bool value);
 	int (*commit_feature_bits)(const struct device *dev);
@@ -56,118 +65,147 @@ __subsystem struct virtio_driver_api {
 };
 
 /**
- * Returns virtqueue at given idx
+ * @brief Return a virtqueue handle.
  *
- * @param dev virtio device it operates on
- * @param queue_idx index of virtqueue to get
- * @return pointer to virtqueue or NULL if not present
+ * Retrieves the virtqueue configured for @p queue_idx. Queue
+ * configuration is performed as part of Virtio 1.3, §3.1 "Device
+ * Initialization" after reading the transport specific registers
+ * described in section "Virtqueues".
+ *
+ * @param dev Virtio device it operates on.
+ * @param queue_idx Index of the virtqueue to get.
+ * @return Pointer to the virtqueue or @c NULL if no queue was configured.
  */
 static inline struct virtq *virtio_get_virtqueue(const struct device *dev, uint16_t queue_idx)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->get_virtqueue(dev, queue_idx);
+        return api->get_virtqueue(dev, queue_idx);
 }
 
 /**
- * Notifies virtqueue
+ * @brief Send a driver notification for a virtqueue.
  *
- * Note that according to spec 2.7.13.3 the device may access the buffers as soon
- * as the avail->idx is increased, which is done by virtq_add_buffer_chain, so the
- * device may access the buffers even without notifying it with virtio_notify_virtqueue
+ * Virtio 1.3, section "Driver Notifications" permits the device to read
+ * buffers as soon as the driver updates the available ring index,
+ * and clarifies that notifications are advisory. The
+ * device may therefore consume buffers even if this helper is not
+ * called.
  *
- * @param dev virtio device it operates on
- * @param queue_idx virtqueue to be notified
+ * @param dev Virtio device it operates on.
+ * @param queue_idx Virtqueue to be notified.
  */
 static inline void virtio_notify_virtqueue(const struct device *dev, uint16_t queue_idx)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	api->notify_virtqueue(dev, queue_idx);
+        api->notify_virtqueue(dev, queue_idx);
 }
 
 /**
- * Returns device specific config
+ * @brief Access the device-specific configuration structure.
  *
- * @param dev virtio device it operates on
- * @return pointer to the device specific config or NULL if its not present
+ * Virtio 1.3, §2.5 "Device Configuration Space" defines device-specific
+ * configuration regions that are readable (and sometimes writable)
+ * by the driver.
+ *
+ * @param dev Virtio device it operates on.
+ * @return Pointer to the device specific configuration space or @c NULL if it
+ *         is not present.
  */
 static inline void *virtio_get_device_specific_config(const struct device *dev)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->get_device_specific_config(dev);
+        return api->get_device_specific_config(dev);
 }
 
 /**
- * Returns feature bit offered by virtio device
+ * @brief Read a device feature bit.
  *
- * @param dev virtio device it operates on
- * @param bit selected bit
- * @return value of the offered feature bit
+ * Part of the feature negotiation sequence in Virtio 1.3, §3.1
+ * "Device Initialization" and §2.2 "Feature Bits".
+ *
+ * @param dev Virtio device it operates on.
+ * @param bit Selected bit number to probe.
+ * @return Value of the offered feature bit.
  */
 static inline bool virtio_read_device_feature_bit(const struct device *dev, int bit)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->read_device_feature_bit(dev, bit);
+        return api->read_device_feature_bit(dev, bit);
 }
 
 /**
- * Sets feature bit
+ * @brief Write a negotiated driver feature bit.
  *
- * @param dev virtio device it operates on
- * @param bit selected bit
- * @param value bit value to write
- * @return 0 on success or negative error code on failure
+ * Invoked while acknowledging features per Virtio 1.3, §3.1 "Device
+ * Initialization" after validating them against §2.2 "Feature Bits".
+ *
+ * @param dev Virtio device it operates on.
+ * @param bit Selected bit number.
+ * @param value Bit value to write.
+ * @return 0 on success or a negative error code on failure.
  */
 static inline int virtio_write_driver_feature_bit(const struct device *dev, int bit, bool value)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->write_driver_feature_bit(dev, bit, value);
+        return api->write_driver_feature_bit(dev, bit, value);
 }
 
 /**
- * Commits feature bits
+ * @brief Commit the negotiated feature set.
  *
- * @param dev virtio device it operates on
- * @return 0 on success or negative error code on failure
+ * Writes the FEATURES_OK status as mandated by Virtio 1.3, §3.1
+ * "Device Initialization" once all desired feature bits have been
+ * acknowledged.
+ *
+ * @param dev Virtio device it operates on.
+ * @return 0 on success or negative error code on failure.
  */
 static inline int virtio_commit_feature_bits(const struct device *dev)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->commit_feature_bits(dev);
+        return api->commit_feature_bits(dev);
 }
 
 /**
- * Initializes virtqueues
+ * @brief Initialize the virtqueues offered by the device.
  *
- * @param dev virtio device it operates on
- * @param num_queues number of queues to initialize
- * @param cb callback called for each available virtqueue
- * @param opaque pointer to user provided data that will be passed to the callback
- * @return 0 on success or negative error code on failure
+ * Corresponds to the queue provisioning steps in Virtio 1.3, §3.1
+ * "Device Initialization" and the queue layout rules in §2.6
+ * "Virtqueues".
+ *
+ * @param dev Virtio device it operates on.
+ * @param num_queues Number of queues to initialize.
+ * @param cb Callback called for each available virtqueue.
+ * @param opaque Pointer to user provided data that will be passed to the callback.
+ * @return 0 on success or negative error code on failure.
  */
 static inline int virtio_init_virtqueues(
-	const struct device *dev, uint16_t num_queues, virtio_enumerate_queues cb, void *opaque)
+        const struct device *dev, uint16_t num_queues, virtio_enumerate_queues cb, void *opaque)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	return api->init_virtqueues(dev, num_queues, cb, opaque);
+        return api->init_virtqueues(dev, num_queues, cb, opaque);
 }
 
 /**
- * Finalizes initialization of the virtio device
+ * @brief Finalize device initialization.
  *
- * @param dev virtio device it operates on
+ * Completes the Virtio 1.3, §3.1 "Device Initialization" sequence by
+ * setting DRIVER_OK once queues and features are ready.
+ *
+ * @param dev Virtio device it operates on.
  */
 static inline void virtio_finalize_init(const struct device *dev)
 {
-	const struct virtio_driver_api *api = dev->api;
+        const struct virtio_driver_api *api = dev->api;
 
-	api->finalize_init(dev);
+        api->finalize_init(dev);
 }
 
 /**

--- a/include/zephyr/drivers/virtio/virtio_config.h
+++ b/include/zephyr/drivers/virtio/virtio_config.h
@@ -7,28 +7,76 @@
 #ifndef ZEPHYR_VIRTIO_VIRTIO_CONFIG_H_
 #define ZEPHYR_VIRTIO_VIRTIO_CONFIG_H_
 
+/**
+ * @name Virtio device status bits
+ * @brief Bit positions in the @c device_status field defined in
+ *        Virtio 1.3, §2.1 "Device Status Field".
+ * @{ */
+/** The guest has recognized the device presence (Virtio 1.3 §2.1). */
 #define DEVICE_STATUS_ACKNOWLEDGE 0
+/** The guest driver is ready to drive the device (Virtio 1.3 §2.1). */
 #define DEVICE_STATUS_DRIVER      1
+/** The driver has successfully set up the device (Virtio 1.3 §2.1). */
 #define DEVICE_STATUS_DRIVER_OK   2
+/**
+ * The driver and device agreed on the negotiated feature set
+ * (Virtio 1.3 §2.1).
+ */
 #define DEVICE_STATUS_FEATURES_OK 3
+/** The device requests a reset to recover from an error (Virtio 1.3 §2.1). */
 #define DEVICE_STATUS_NEEDS_RESET 6
+/** The device has experienced a non-recoverable error (Virtio 1.3 §2.1). */
 #define DEVICE_STATUS_FAILED      7
+/** @} */
 
+/**
+ * @name Core feature bits shared by all Virtio devices
+ * @brief Negotiable feature bit positions described in Virtio 1.3,
+ *        §3 "Reserved Feature Bits".
+ * @{ */
+/** Virtqueue layout can deviate from the legacy format (Virtio 1.3 §3). */
 #define VIRTIO_F_ANY_LAYOUT      27
+/** Device complies with Virtio 1.0+ semantics (Virtio 1.3 §3). */
 #define VIRTIO_F_VERSION_1       32
+/** Device needs platform-specific DMA handling (Virtio 1.3 §3). */
 #define VIRTIO_F_ACCESS_PLATFORM 33
+/** @} */
 
+/**
+ * @name Split virtqueue feature bits
+ * @brief Virtqueue extensions defined in Virtio 1.3, §3 "Reserved
+ *        Feature Bits".
+ * @{ */
+/** Descriptors can reference descriptor tables (Virtio 1.3 §3). */
 #define VIRTIO_RING_F_INDIRECT_DESC 28
+/** Driver/device use event index for notifications (Virtio 1.3 §3). */
 #define VIRTIO_RING_F_EVENT_IDX     29
+/** @} */
 
+/**
+ * @brief Flag value for suppressing used-buffer notifications in the
+ *        split available ring as described in Virtio 1.3,
+ *        section "The Virtqueue Available Ring".
+ */
+/** Driver requests the device to skip interrupts (Virtio 1.3 §2.6.6). */
 #define VIRTQ_AVAIL_F_NO_INTERRUPT 1
 
+/**
+ * @brief Flag value for suppressing available-buffer notifications in
+ *        the split used ring as described in Virtio 1.3,
+ *        section "The Virtqueue Used Ring".
+ */
+/** Device requests the driver to suppress notifications (Virtio 1.3 §2.6.7). */
 #define VIRTQ_USED_F_NO_NOTIFY 1
 
 /* Ranges of feature bits for specific device types (see spec 2.2)*/
+/** Start of the first device-specific feature range (Virtio 1.3 §2.2). */
 #define DEV_TYPE_FEAT_RANGE_0_BEGIN 0
+/** End of the first device-specific feature range (Virtio 1.3 §2.2). */
 #define DEV_TYPE_FEAT_RANGE_0_END   23
+/** Start of the second device-specific feature range (Virtio 1.3 §2.2). */
 #define DEV_TYPE_FEAT_RANGE_1_BEGIN 50
+/** End of the second device-specific feature range (Virtio 1.3 §2.2). */
 #define DEV_TYPE_FEAT_RANGE_1_END   127
 
 /*
@@ -36,8 +84,16 @@
  * the same bits are responsible for the same interrupts, so defines
  * with them can be unified
  */
+/**
+ * @name Virtio transport interrupt bits
+ * @brief Shared interrupt status bit positions defined in Virtio 1.3,
+ *        §4.1.4.5 and §4.2.2 for PCI and MMIO transports.
+ * @{ */
+/** A virtqueue has pending used buffers (Virtio 1.3 §4.1.4.5/§4.2.2). */
 #define VIRTIO_QUEUE_INTERRUPT                1
+/** Device configuration space has changed (Virtio 1.3 §4.1.4.5/§4.2.2). */
 #define VIRTIO_DEVICE_CONFIGURATION_INTERRUPT 2
+/** @} */
 
 /*
  * VIRTIO-MMIO register definitions.
@@ -46,35 +102,71 @@
  * https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.pdf
  */
 
+/**
+ * @name Virtio-MMIO register offsets
+ * @brief Register layout defined in Virtio 1.3,
+ *        §4.2.2 "MMIO Device Register Layout" (offsets in bytes).
+ * @{ */
+/** Magic value identifying the virtio MMIO device (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_MAGIC_VALUE         0x000
+/** Virtio specification version exposed by the device (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_VERSION             0x004
+/** Device type identifier register (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_DEVICE_ID           0x008
+/** Vendor-specific identifier register (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_VENDOR_ID           0x00c
+/** Lower 32 bits of the device feature bitmap (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_DEVICE_FEATURES     0x010
+/** Selector choosing the device feature word (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_DEVICE_FEATURES_SEL 0x014
+/** Lower 32 bits of the negotiated driver feature bitmap (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_DRIVER_FEATURES     0x020
+/** Selector choosing the driver feature word (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_DRIVER_FEATURES_SEL 0x024
+/** Virtqueue index selected for subsequent accesses (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_SEL           0x030
+/** Maximum queue size supported by the selected virtqueue (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_SIZE_MAX      0x034
+/** Queue size chosen by the driver for the selected virtqueue (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_SIZE          0x038
+/** Ready flag indicating driver ownership of the queue (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_READY         0x044
+/** Doorbell register for queue notifications (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_NOTIFY        0x050
+/** Pending interrupt summary bits (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_INTERRUPT_STATUS    0x060
+/** Interrupt acknowledgement register (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_INTERRUPT_ACK       0x064
+/** Device status field mirror (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_STATUS              0x070
+/** Lower 32 bits of the descriptor table address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_DESC_LOW      0x080
+/** Upper 32 bits of the descriptor table address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_DESC_HIGH     0x084
+/** Lower 32 bits of the available ring address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_AVAIL_LOW     0x090
+/** Upper 32 bits of the available ring address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_AVAIL_HIGH    0x094
+/** Lower 32 bits of the used ring address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_USED_LOW      0x0a0
+/** Upper 32 bits of the used ring address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_USED_HIGH     0x0a4
+/** Shared memory region selector (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_SHM_SEL             0x0ac
+/** Lower 32 bits of the shared memory length (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_SHM_LEN_LOW         0x0b0
+/** Upper 32 bits of the shared memory length (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_SHM_LEN_HIGH        0x0b4
+/** Lower 32 bits of the shared memory base address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_SHM_BASE_LOW        0x0b8
+/** Upper 32 bits of the shared memory base address (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_SHM_BASE_HIGH       0x0bc
+/** Queue reset control register (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_QUEUE_RESET         0x0c0
+/** Generation counter for configuration space (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_CONFIG_GENERATION   0x0fc
+/** Base offset of the device configuration structure (Virtio 1.3 §4.2.2). */
 #define VIRTIO_MMIO_CONFIG              0x100
+/** @} */
 
 #endif /* ZEPHYR_VIRTIO_VIRTIO_CONFIG_H_ */

--- a/include/zephyr/fs/virtiofs.h
+++ b/include/zephyr/fs/virtiofs.h
@@ -12,8 +12,21 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Runtime metadata gathered from the virtio-fs handshake.
+ *
+ * Virtio 1.3, Chapter 5 "Device Types", §"File System Device"
+ * requires the driver to initiate a FUSE session and honour the
+ * limits advertised during @c FUSE_INIT. This structure keeps track
+ * of those negotiated parameters for a mounted instance.
+ */
 struct virtiofs_fs_data {
-	uint32_t max_write;
+        /**
+         * Maximum payload size accepted by FUSE_WRITE as reported in the
+         * FUSE_INIT reply, see Virtio 1.3, "File System Device" — Device
+         * Operation.
+         */
+        uint32_t max_write;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- add clause-specific Doxygen annotations for each virtio device status and feature bit macro
- explain every virtio transport interrupt flag and MMIO register offset with Virtio 1.3 references

## Testing
- not run (documentation updates)


------
https://chatgpt.com/codex/tasks/task_e_68d5004c7d9c832297b40e47f1a4c254