### PR TITLE
drivers: audio: aw88298: honor I2S polarity and slave options

### DIFF
--- a/drivers/audio/aw88298.c
+++ b/drivers/audio/aw88298.c
@@ -37,14 +37,20 @@ LOG_MODULE_REGISTER(aw88298);
 
 #define AW88298_REG_SYSCTRL2_HMUTE BIT(4)
 
+#define AW88298_REG_I2SCTRL_BCLK_POL BIT(14)
+#define AW88298_REG_I2SCTRL_LRCLK_POL BIT(13)
 #define AW88298_REG_I2SCTRL_I2SMD  (BIT_MASK(4) << 8)
 #define AW88298_REG_I2SCTRL_I2SFS  (BIT_MASK(2) << 6)
 #define AW88298_REG_I2SCTRL_I2SBCK (BIT_MASK(2) << 4)
 #define AW88298_REG_I2SCTRL_I2SSR  BIT_MASK(4)
 
-#define AW88298_REG_I2SCTRL_I2S_CFG_MASK BIT_MASK(10)
-
 #define AW88298_I2SCTRL_FRAME_FLAGS BIT(12)
+
+#define AW88298_REG_I2SCTRL_I2S_CFG_MASK                                                   \
+        (AW88298_REG_I2SCTRL_BCLK_POL | AW88298_REG_I2SCTRL_LRCLK_POL |                \
+         AW88298_I2SCTRL_FRAME_FLAGS | AW88298_REG_I2SCTRL_I2SMD |                     \
+         AW88298_REG_I2SCTRL_I2SFS | AW88298_REG_I2SCTRL_I2SBCK |                      \
+         AW88298_REG_I2SCTRL_I2SSR)
 
 #define AW88298_REG_HAGCCFG4_VOL (BIT_MASK(8) << 8)
 
@@ -59,6 +65,7 @@ LOG_MODULE_REGISTER(aw88298);
 #define AW88298_VOLUME_MAX 0x00FF
 
 #define AW88298_I2SCTRL_MODE_I2S 0x4U
+#define AW88298_I2SCTRL_MODE_SLAVE BIT(3)
 
 enum {
 	AW88298_I2SCTRL_FS_32BIT, //0U
@@ -203,11 +210,14 @@ static int aw88298_get_i2s_mode_code(audio_dai_type_t type, uint16_t *code)
 
 static int aw88298_configure(const struct device *dev, struct audio_codec_cfg *cfg)
 {
-	uint16_t rate_code;
-	uint16_t mode_code;
-	uint16_t fs_code;
-	uint16_t bck_code;
-	int ret;
+        uint16_t rate_code;
+        uint16_t mode_code;
+        uint16_t fs_code;
+        uint16_t bck_code;
+        uint16_t clk_flags = 0U;
+        i2s_opt_t options;
+        i2s_fmt_t format;
+        int ret;
 
 	if ((cfg->dai_cfg.i2s.channels != 1U) && (cfg->dai_cfg.i2s.channels != 2U)) {
 		LOG_ERR("Unsupported channel count %u", cfg->dai_cfg.i2s.channels);
@@ -224,21 +234,82 @@ static int aw88298_configure(const struct device *dev, struct audio_codec_cfg *c
 		return ret;
 	}
 
-	ret = aw88298_get_sample_rate_code(cfg->dai_cfg.i2s.frame_clk_freq, &rate_code);
-	if (ret < 0) {
-		return ret;
-	}
+        format = cfg->dai_cfg.i2s.format;
 
-	if ((cfg->dai_route != AUDIO_ROUTE_PLAYBACK) && (cfg->dai_route != AUDIO_ROUTE_BYPASS)) {
-		LOG_ERR("Unsupported route %u", cfg->dai_route);
-		return -ENOTSUP;
-	}
+        if ((format & I2S_FMT_DATA_FORMAT_MASK) != I2S_FMT_DATA_FORMAT_I2S) {
+                LOG_ERR("Unsupported I2S data format 0x%x", format & I2S_FMT_DATA_FORMAT_MASK);
+                return -ENOTSUP;
+        }
 
-	LOG_DBG("Configure: rate=%u channels=%u options=0x%x", cfg->dai_cfg.i2s.frame_clk_freq,
-		cfg->dai_cfg.i2s.channels, cfg->dai_cfg.i2s.options);
+        if ((format & I2S_FMT_DATA_ORDER_LSB) != 0U) {
+                LOG_ERR("LSB-first data ordering not supported");
+                return -ENOTSUP;
+        }
 
-	rate_code |= AW88298_I2SCTRL_FRAME_FLAGS | AW88298_I2SCTRL_I2SMD_VAL(mode_code) |
-		     AW88298_I2SCTRL_I2SFS_VAL(fs_code) | AW88298_I2SCTRL_I2SBCK_VAL(bck_code);
+        switch (format & I2S_FMT_CLK_FORMAT_MASK) {
+        case I2S_FMT_CLK_NF_NB:
+                break;
+        case I2S_FMT_CLK_NF_IB:
+                clk_flags |= AW88298_REG_I2SCTRL_BCLK_POL;
+                break;
+        case I2S_FMT_CLK_IF_NB:
+                clk_flags |= AW88298_REG_I2SCTRL_LRCLK_POL;
+                break;
+        case I2S_FMT_CLK_IF_IB:
+                clk_flags |= AW88298_REG_I2SCTRL_LRCLK_POL | AW88298_REG_I2SCTRL_BCLK_POL;
+                break;
+        default:
+                LOG_ERR("Unsupported I2S clock format 0x%x", format & I2S_FMT_CLK_FORMAT_MASK);
+                return -ENOTSUP;
+        }
+
+        if ((format & ~(I2S_FMT_DATA_FORMAT_MASK | I2S_FMT_DATA_ORDER_LSB |
+                         I2S_FMT_CLK_FORMAT_MASK)) != 0U) {
+                LOG_WRN("Ignoring unsupported I2S format bits 0x%x",
+                        format & ~(I2S_FMT_DATA_FORMAT_MASK | I2S_FMT_DATA_ORDER_LSB |
+                                   I2S_FMT_CLK_FORMAT_MASK));
+        }
+
+        ret = aw88298_get_sample_rate_code(cfg->dai_cfg.i2s.frame_clk_freq, &rate_code);
+        if (ret < 0) {
+                return ret;
+        }
+
+        if ((cfg->dai_route != AUDIO_ROUTE_PLAYBACK) && (cfg->dai_route != AUDIO_ROUTE_BYPASS)) {
+                LOG_ERR("Unsupported route %u", cfg->dai_route);
+                return -ENOTSUP;
+        }
+
+        options = cfg->dai_cfg.i2s.options;
+
+        if ((options & (I2S_OPT_LOOPBACK | I2S_OPT_PINGPONG)) != 0U) {
+                LOG_WRN("Ignoring unsupported I2S options 0x%x", options &
+                        (I2S_OPT_LOOPBACK | I2S_OPT_PINGPONG));
+        }
+
+        if ((options & I2S_OPT_BIT_CLK_GATED) != 0U) {
+                LOG_WRN("Bit clock gating not supported");
+        }
+
+        if (((options & I2S_OPT_BIT_CLK_SLAVE) != 0U) !=
+            ((options & I2S_OPT_FRAME_CLK_SLAVE) != 0U)) {
+                LOG_ERR("Inconsistent clock master/slave options 0x%x", options);
+                return -ENOTSUP;
+        }
+
+        if ((options & I2S_OPT_BIT_CLK_SLAVE) == 0U) {
+                LOG_ERR("AW88298 requires external LRCLK/BCLK (slave mode)");
+                return -ENOTSUP;
+        }
+
+        mode_code |= AW88298_I2SCTRL_MODE_SLAVE;
+
+        LOG_DBG("Configure: rate=%u channels=%u options=0x%x", cfg->dai_cfg.i2s.frame_clk_freq,
+                cfg->dai_cfg.i2s.channels, cfg->dai_cfg.i2s.options);
+
+        rate_code |= AW88298_I2SCTRL_FRAME_FLAGS | clk_flags |
+                     AW88298_I2SCTRL_I2SMD_VAL(mode_code) |
+                     AW88298_I2SCTRL_I2SFS_VAL(fs_code) | AW88298_I2SCTRL_I2SBCK_VAL(bck_code);
 
 	ret = aw88298_update_reg(dev, AW88298_REG_SYSCTRL,
 				 AW88298_REG_SYSCTRL_I2SEN | AW88298_REG_SYSCTRL_PWDN,

--- a/samples/drivers/audio/aw88298/README.rst
+++ b/samples/drivers/audio/aw88298/README.rst
@@ -26,6 +26,13 @@ on the internal I2C bus at address ``0x36``, its enable pin is routed through th
 AW9523 GPIO expander (port 0, pin 2), and the audio stream uses ``I2S1`` with
 ``GPIO34`` (BCK), ``GPIO33`` (LRCK), and ``GPIO13`` (SDOUT).
 
+.. note::
+
+   The AW88298 always operates as an I2S slave. The codec driver expects the
+   SoC I2S peripheral to provide both bit and frame clocks; configurations that
+   attempt to let the codec drive the clocks (for example by enabling
+   ``CONFIG_USE_CODEC_CLOCK``) will fail during initialization.
+
 Building and Running
 ********************
 

--- a/samples/drivers/audio/aw88298/src/main.c
+++ b/samples/drivers/audio/aw88298/src/main.c
@@ -148,10 +148,9 @@ int main(void)
 	audio_cfg.dai_cfg.i2s.channels = 2;
 	audio_cfg.dai_cfg.i2s.format = I2S_FMT_DATA_FORMAT_I2S;
 #ifdef CONFIG_USE_CODEC_CLOCK
-	audio_cfg.dai_cfg.i2s.options = I2S_OPT_FRAME_CLK_MASTER | I2S_OPT_BIT_CLK_MASTER;
-#else
-	audio_cfg.dai_cfg.i2s.options = I2S_OPT_FRAME_CLK_SLAVE | I2S_OPT_BIT_CLK_SLAVE;
+#error "The AW88298 codec operates as an I2S slave; disable CONFIG_USE_CODEC_CLOCK"
 #endif
+        audio_cfg.dai_cfg.i2s.options = I2S_OPT_FRAME_CLK_SLAVE | I2S_OPT_BIT_CLK_SLAVE;
 	audio_cfg.dai_cfg.i2s.frame_clk_freq = SAMPLE_FREQUENCY;
 	audio_cfg.dai_cfg.i2s.mem_slab = &mem_slab;
 	audio_cfg.dai_cfg.i2s.block_size = BLOCK_SIZE;
@@ -178,11 +177,7 @@ int main(void)
 	config.word_size = SAMPLE_BIT_WIDTH;
 	config.channels = NUMBER_OF_CHANNELS;
 	config.format = I2S_FMT_DATA_FORMAT_I2S;
-#ifdef CONFIG_USE_CODEC_CLOCK
-	config.options = I2S_OPT_BIT_CLK_SLAVE | I2S_OPT_FRAME_CLK_SLAVE;
-#else
-	config.options = I2S_OPT_BIT_CLK_MASTER | I2S_OPT_FRAME_CLK_MASTER;
-#endif
+        config.options = I2S_OPT_BIT_CLK_MASTER | I2S_OPT_FRAME_CLK_MASTER;
 	config.frame_clk_freq = SAMPLE_FREQUENCY;
 	config.mem_slab = &mem_slab;
 	config.block_size = BLOCK_SIZE;


### PR DESCRIPTION
## Summary
- define register bits for AW88298 I2S clock polarity and slave mode handling
- validate codec configuration to combine polarity flags and enforce slave clocking
- document and update the AW88298 sample so it always drives the codec as an I2S slave

## Testing
- Not run (west tool unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e085beb5048322b4bff497e9acc734