### PR TITLE
Fix RA4M1 FSP critical section macros

### DIFF
--- a/soc/renesas/ra/ra4m1/soc.h
+++ b/soc/renesas/ra/ra4m1/soc.h
@@ -13,9 +13,11 @@
 
 #include <zephyr/irq.h>
 
-#define FSP_CRITICAL_SECTION_DEFINE            unsigned int irq_lock_key
-#define FSP_CRITICAL_SECTION_ENTER             irq_lock_key = irq_lock();
-#define FSP_CRITICAL_SECTION_EXIT              irq_unlock(irq_lock_key);
+#ifndef _ASMLANGUAGE
+#define FSP_CRITICAL_SECTION_DEFINE            unsigned int irq_lock_key __maybe_unused
+#define FSP_CRITICAL_SECTION_ENTER             do { irq_lock_key = irq_lock(); } while (false)
+#define FSP_CRITICAL_SECTION_EXIT              do { irq_unlock(irq_lock_key); } while (false)
+#endif
 
 #include <bsp_api.h>
 


### PR DESCRIPTION
## Summary
- wrap the RA4M1 FSP critical section macros with do-while blocks to ensure safe usage
- mark the IRQ lock key as maybe_unused and hide the macros from assembler sources

## Testing
- west build -p -b ek_ra4m1 samples/hello_world/ *(fails: west not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12fc511248322a1fd81e531e0780d