### PR TITLE
Update devicetree macros BNF for child index macros

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -103,8 +103,8 @@ node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_NODELABEL" [ %s"_VARGS" ]
 ; These are used internally by DT_NUM_NODELABELS
 node-macro =/ %s"DT_N" path-id %s"_NODELABEL_NUM"
-; The node's zero-based index in the list of it's parent's child nodes.
-node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX"
+; Macros which expand to the node identifiers for each child by index.
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX_" DIGIT
 ; The node's status macro; dt-name in this case is something like "okay"
 ; or "disabled".
 node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name


### PR DESCRIPTION
## Summary
- document the DT_N_*_CHILD_IDX_* macros in the devicetree macros ABNF grammar
- clarify that the macros expand to child node identifiers by index

## Testing
- python3 doc/tools/validate_abnf.py doc/build/dts/macros.bnf

------
https://chatgpt.com/codex/tasks/task_e_68e17b22c48c8322ada41327fa59696f