### PR TITLE
Simplify pinctrl binary info generation

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -96,6 +96,9 @@ node-macro =/ %s"DT_N" path-id %s"_FOREACH_NODELABEL" [ %s"_VARGS" ]
 node-macro =/ %s"DT_N" path-id %s"_NODELABEL_NUM"
 ; The node's zero-based index in the list of it's parent's child nodes.
 node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX"
+; Identifies child nodes by ordinal number.
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX_" *DIGIT
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX_" *DIGIT "_EXISTS"
 ; The node's status macro; dt-name in this case is something like "okay"
 ; or "disabled".
 node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -436,6 +436,44 @@
 #define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
 
 /**
+ * @brief Get a child node by index
+ *
+ * This macro retrieves a child node of a specified node by its
+ * index. The index corresponds to the order in which the child nodes
+ * are defined in the Devicetree source.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ * / {
+ *     parent_node {
+ *         first_child {
+ *             reg = <0>;
+ *         };
+ *         second_child {
+ *             reg = <1>;
+ *         };
+ *     };
+ * };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ * DT_CHILD_BY_IDX(DT_NODELABEL(parent_node), 0) // "first_child"
+ * DT_CHILD_BY_IDX(DT_NODELABEL(parent_node), 1) // "second_child"
+ * @endcode
+ *
+ * @param node_id The identifier of the parent node. This can be obtained
+ *                using macros like DT_NODELABEL(), DT_PATH(), or similar.
+ * @param idx     The index of the child node to retrieve. Must be within
+ *                the range of 0 to DT_CHILD_NUM(node_id) - 1.
+ *
+ * @return The identifier of the child node at the specified index.
+ */
+#define DT_CHILD_BY_IDX(node_id, idx) UTIL_CAT(UTIL_CAT(node_id, _CHILD_IDX_), idx)
+
+/**
  * @brief Get a node identifier for a status `okay` node with a compatible
  *
  * Use this if you want to get an arbitrary enabled node with a given

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -89,9 +89,11 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/pico_platform_panic/include
     ${common_dir}/boot_picoboot_headers/include
     ${common_dir}/boot_picobin_headers/include
+    ${common_dir}/pico_binary_info/include
     ${rp2xxx_dir}/hardware_regs/include
     ${rp2xxx_dir}/hardware_structs/include
     ${rp2xxx_dir}/pico_platform/include
+    ${boot_stage_dir}/include
     ${CMAKE_CURRENT_LIST_DIR}
   )
 

--- a/modules/hal_rpi_pico/pico/config_autogen.h
+++ b/modules/hal_rpi_pico/pico/config_autogen.h
@@ -29,8 +29,12 @@
 /* Convert uses of asm, which is not supported in c99, to __asm */
 #define asm __asm
 
-/* Disable binary info */
+/* Configure binary info */
+#ifndef CONFIG_RPI_PICO_BINARY_INFO
 #define PICO_NO_BINARY_INFO 1
+#else
+#define PICO_NO_BINARY_INFO 0
+#endif
 
 #ifdef CONFIG_DT_HAS_RASPBERRYPI_PICO_XOSC_ENABLED
 #include <zephyr/devicetree.h>

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -478,9 +478,12 @@ def write_children(node: edtlib.Node) -> None:
     out_dt_define(f"{node.z_path_id}_CHILD_NUM", len(node.children))
 
     ok_nodes_num = 0
-    for child in node.children.values():
+    for i, child in enumerate(node.children.values()):
         if child.status == "okay":
             ok_nodes_num = ok_nodes_num + 1
+
+        out_dt_define(f"{node.z_path_id}_CHILD_IDX_{i}", f"DT_{child.z_path_id}")
+        out_dt_define(f"{node.z_path_id}_CHILD_IDX_{i}_EXISTS", 1)
 
     out_dt_define(f"{node.z_path_id}_CHILD_NUM_STATUS_OKAY", ok_nodes_num)
 

--- a/soc/raspberrypi/rpi_pico/common/CMakeLists.txt
+++ b/soc/raspberrypi/rpi_pico/common/CMakeLists.txt
@@ -8,3 +8,16 @@ zephyr_sources(
 )
 
 zephyr_sources_ifdef(CONFIG_RPI_PICO_ROM_BOOTLOADER rom_bootloader.c)
+
+zephyr_library_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO
+	binary_info.c
+	binary_info_header.S
+)
+
+zephyr_linker_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO
+	ROM_START SORT_KEY 0x0binary_info_header binary_info_header.ld
+)
+
+zephyr_linker_sources_ifdef(CONFIG_RPI_PICO_BINARY_INFO
+	RODATA binary_info.ld
+)

--- a/soc/raspberrypi/rpi_pico/common/Kconfig
+++ b/soc/raspberrypi/rpi_pico/common/Kconfig
@@ -1,0 +1,65 @@
+# Copyright (c) 2024 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config RPI_PICO_BINARY_INFO
+	bool "Generate RaspberryPi Pico binary info"
+	default y
+	help
+	  Binary info is able to embed machine readable information with the binary in FLASH.
+	  It can read with picotool(https://github.com/raspberrypi/picotool).
+
+if RPI_PICO_BINARY_INFO
+
+config RPI_PICO_BINARY_INFO_PROGRAM_NAME_ENABLE
+	bool "Override program name in binary info"
+
+config RPI_PICO_BINARY_INFO_PROGRAM_NAME
+	string "Override string for program name in binary info"
+	depends on RPI_PICO_BINARY_INFO_PROGRAM_NAME_ENABLE
+
+config RPI_PICO_BINARY_INFO_PROGRAM_URL_ENABLE
+	bool "Override program url in binary info"
+
+config RPI_PICO_BINARY_INFO_PROGRAM_URL
+	string "String for program description in binary info"
+	depends on RPI_PICO_BINARY_INFO_PROGRAM_URL_ENABLE
+
+config RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION_ENABLE
+	bool "Override program descrpition in binary info"
+
+config RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION
+	string "String for program description in binary info"
+	depends on RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION_ENABLE
+
+config RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE_ENABLE
+	bool "Override build date in binary info"
+
+config RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE
+	string "Override string for build date in binary info"
+	depends on RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE_ENABLE
+
+config RPI_PICO_BINARY_INFO_PROGRAM_VERSION_STRING_ENABLE
+	bool "Override program version in binary info"
+	default y
+
+config RPI_PICO_BINARY_INFO_SDK_VERSION_STRING_ENABLE
+	bool "Override sdk version in binary info"
+	default y
+
+config RPI_PICO_BINARY_INFO_PICO_BOARD_ENABLE
+	bool "Override board in binary info"
+	default y
+
+config RPI_PICO_BINARY_INFO_ATTRIBUTE_BUILD_TYPE_ENABLE
+	bool "Override board in binary info"
+	default y
+
+config RPI_PICO_BINARY_INFO_BOOT_STAGE2_NAME_ENABLE
+	bool "Override board in binary info"
+	default y
+
+config RPI_PICO_BINARY_INFO_PINS_WITH_FUNC_ENABLE
+	bool "Override board in binary info"
+	default y
+
+endif

--- a/soc/raspberrypi/rpi_pico/common/binary_info.c
+++ b/soc/raspberrypi/rpi_pico/common/binary_info.c
@@ -40,9 +40,11 @@
 #define PINCTRL_GROUP_PIN_COUNT(node_id)                                                           \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, pinmux), (DT_PROP_LEN(node_id, pinmux)), (0))
 
-#define PINCTRL_OFFSET_TERM(i, node_id) +PINCTRL_GROUP_PIN_COUNT(DT_CHILD_BY_IDX(node_id, i))
-#define PINCTRL_GROUP_OFFSET(node_id, idx) (0 LISTIFY(idx, PINCTRL_OFFSET_TERM, (), node_id))
-#define PINCTRL_TOTAL_PINS(node_id) PINCTRL_GROUP_OFFSET(node_id, DT_CHILD_NUM(node_id))
+#define PINCTRL_OFFSET_IF_PRECEDES(child, target)                                                   \
+        ((DT_NODE_CHILD_IDX(child) < DT_NODE_CHILD_IDX(target)) ? PINCTRL_GROUP_PIN_COUNT(child) : 0)
+#define PINCTRL_GROUP_OFFSET(parent, child)                                                         \
+        (0 DT_FOREACH_CHILD_SEP_VARGS(parent, PINCTRL_OFFSET_IF_PRECEDES, (+), child))
+#define PINCTRL_TOTAL_PINS(node_id) (0 DT_FOREACH_CHILD_SEP(node_id, PINCTRL_GROUP_PIN_COUNT, (+)))
 
 /* Iterate groups and subgroups */
 
@@ -58,9 +60,8 @@
 	(IS_LAST_PIN(end, i, offset) ? ENCODE_PIN(n, i, (offset) + 1) : 0)
 #define PIN_ENTRY(n, p, i, off) (DT_PROP_HAS_IDX(n, p, i) ? ENCODE_PIN(n, i, off) : 0)
 #define ENCODE_EACH_PIN(n, p, i, end)                                                              \
-	PIN_ENTRY(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), DT_NODE_CHILD_IDX(n))) |             \
-		PIN_TERMINATE(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), DT_NODE_CHILD_IDX(n)),   \
-			      end)
+        PIN_ENTRY(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), n)) |                                \
+                PIN_TERMINATE(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), n), end)
 #define ENCODE_GROUP_PINS(n) (EACH_PINCTRL_GROUP(n, (|), ENCODE_EACH_PIN, PINCTRL_TOTAL_PINS(n)))
 
 /* Get group-wide pin functions */
@@ -81,7 +82,7 @@
 	bi_decl(BI_ENCODE_PINS_WITH_FUNC(BI_PINS_ENCODING_MULTI | (GROUP_PIN_FUNC(n) << 3) |       \
 					 ENCODE_GROUP_PINS(n)))
 
-#define BI_PINS_FROM_PINCTRL_GROUP(n, idx) BI_PINS_FROM_PINCTRL_GROUP_(DT_CHILD_BY_IDX(n, idx))
+#define BI_PINS_FROM_PINCTRL_CHILD(child) BI_PINS_FROM_PINCTRL_GROUP_(child);
 
 #ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME
 #define BI_PROGRAM_NAME CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME
@@ -148,100 +149,5 @@ bi_decl(bi_program_build_attribute((uint32_t)"Release"));
 #endif
 
 #ifdef CONFIG_RPI_PICO_BINARY_INFO_PINS_WITH_FUNC_ENABLE
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 0
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 0);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 1
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 1);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 2
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 2);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 3
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 3);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 4
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 4);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 5
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 5);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 6
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 6);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 7
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 7);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 8
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 8);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 9
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 9);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 10
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 10);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 11
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 11);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 12
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 12);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 13
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 13);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 14
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 14);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 15
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 15);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 16
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 16);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 17
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 17);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 18
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 18);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 19
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 19);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 20
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 20);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 21
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 21);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 22
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 22);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 23
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 23);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 24
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 24);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 25
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 25);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 26
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 26);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 27
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 27);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 28
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 28);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 29
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 29);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 30
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 30);
-#endif
-#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 31
-BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 31);
-#endif
+DT_FOREACH_CHILD(DT_NODELABEL(pinctrl), BI_PINS_FROM_PINCTRL_CHILD)
 #endif

--- a/soc/raspberrypi/rpi_pico/common/binary_info.c
+++ b/soc/raspberrypi/rpi_pico/common/binary_info.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util_macro.h>
+
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-pinctrl-common.h>
+
+#include <soc.h>
+
+#include <boot_stage2/config.h>
+#include <pico/binary_info.h>
+
+#include <version.h>
+#ifdef HAS_APP_VERSION
+#include <app_version.h>
+#endif
+
+/* utils for pin encoding calcluation */
+
+#ifdef CONFIG_SOC_RP2040
+#define ENCODE_PIN(n, idx, offset) ((uint32_t)PIN_NUM(n, idx) << (2 + (idx + offset + 1) * 5))
+#define MAX_PIN_ENTRY              4
+#define BI_ENCODE_PINS_WITH_FUNC   __bi_encoded_pins_with_func
+#else
+#define ENCODE_PIN(n, idx, offset) ((uint64_t)PIN_NUM(n, idx) << ((idx + offset + 1) * 8))
+#define MAX_PIN_ENTRY              6
+#define BI_ENCODE_PINS_WITH_FUNC   __bi_encoded_pins_64_with_func
+#endif
+
+#define PIN_NUM(n, idx)  ((DT_PROP_BY_IDX(n, pinmux, idx) >> RP2_PIN_NUM_POS) & RP2_PIN_NUM_MASK)
+#define PIN_FUNC(n, idx) (DT_PROP_BY_IDX(n, pinmux, idx) & RP2_ALT_FUNC_MASK)
+
+/* Pin counts and offsets for groups */
+
+#define PINCTRL_GROUP_PIN_COUNT(node_id)                                                           \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, pinmux), (DT_PROP_LEN(node_id, pinmux)), (0))
+
+#define PINCTRL_OFFSET_TERM(i, node_id) +PINCTRL_GROUP_PIN_COUNT(DT_CHILD_BY_IDX(node_id, i))
+#define PINCTRL_GROUP_OFFSET(node_id, idx) (0 LISTIFY(idx, PINCTRL_OFFSET_TERM, (), node_id))
+#define PINCTRL_TOTAL_PINS(node_id) PINCTRL_GROUP_OFFSET(node_id, DT_CHILD_NUM(node_id))
+
+/* Iterate groups and subgroups */
+
+#define EACH_PINCTRL_SUBGROUP(n, fn, sep, ...)                                                     \
+	DT_FOREACH_PROP_ELEM_SEP_VARGS(n, pinmux, fn, sep, __VA_ARGS__)
+#define EACH_PINCTRL_GROUP(n, sep, fn, ...)                                                        \
+	DT_FOREACH_CHILD_SEP_VARGS(n, EACH_PINCTRL_SUBGROUP, sep, fn, sep, __VA_ARGS__)
+
+/* Encode the pins in a group */
+
+#define IS_LAST_PIN(end, idx, off) (((idx) + (off) + 1) == (end))
+#define PIN_TERMINATE(n, p, i, offset, end)                                                        \
+	(IS_LAST_PIN(end, i, offset) ? ENCODE_PIN(n, i, (offset) + 1) : 0)
+#define PIN_ENTRY(n, p, i, off) (DT_PROP_HAS_IDX(n, p, i) ? ENCODE_PIN(n, i, off) : 0)
+#define ENCODE_EACH_PIN(n, p, i, end)                                                              \
+	PIN_ENTRY(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), DT_NODE_CHILD_IDX(n))) |             \
+		PIN_TERMINATE(n, p, i, PINCTRL_GROUP_OFFSET(DT_PARENT(n), DT_NODE_CHILD_IDX(n)),   \
+			      end)
+#define ENCODE_GROUP_PINS(n) (EACH_PINCTRL_GROUP(n, (|), ENCODE_EACH_PIN, PINCTRL_TOTAL_PINS(n)))
+
+/* Get group-wide pin functions */
+
+#define EACH_PIN_FUNC(n, p, i, _) PIN_FUNC(n, i)
+#define GROUP_PIN_FUNC(n)         (EACH_PINCTRL_GROUP(n, (|), EACH_PIN_FUNC))
+
+/* Check if pin functions are all equal within a group */
+
+#define EACH_PIN_FUNC_IS(n, p, i, func) (PIN_FUNC(n, i) == func)
+#define ALL_PIN_FUNC_IS(n, pinfunc)     (EACH_PINCTRL_GROUP(n, (&&), EACH_PIN_FUNC_IS, pinfunc))
+
+#define BI_PINS_FROM_PINCTRL_GROUP_(n)                                                             \
+	BUILD_ASSERT(PINCTRL_TOTAL_PINS(n) > 0, "Group must contain at least one pin");            \
+	BUILD_ASSERT(PINCTRL_TOTAL_PINS(n) <= MAX_PIN_ENTRY, "Too many pin in group");             \
+	BUILD_ASSERT(ALL_PIN_FUNC_IS(n, GROUP_PIN_FUNC(n)),                                        \
+		     "Group must contain only single function type");                              \
+	bi_decl(BI_ENCODE_PINS_WITH_FUNC(BI_PINS_ENCODING_MULTI | (GROUP_PIN_FUNC(n) << 3) |       \
+					 ENCODE_GROUP_PINS(n)))
+
+#define BI_PINS_FROM_PINCTRL_GROUP(n, idx) BI_PINS_FROM_PINCTRL_GROUP_(DT_CHILD_BY_IDX(n, idx))
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME
+#define BI_PROGRAM_NAME CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION
+#define BI_PROGRAM_DESCRIPTION CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_URL
+#define BI_PROGRAM_URL CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_URL
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE
+#define BI_PROGRAM_BUILD_DATE CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE
+#else
+#define BI_PROGRAM_BUILD_DATE __DATE__
+#endif
+
+extern uint32_t __rom_region_end;
+bi_decl(bi_binary_end((intptr_t)&__rom_region_end));
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_NAME_ENABLE
+bi_decl(bi_program_name((uint32_t)BI_PROGRAM_NAME));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PICO_BOARD_ENABLE
+bi_decl(bi_string(BINARY_INFO_TAG_RASPBERRY_PI, BINARY_INFO_ID_RP_PICO_BOARD,
+		  (uint32_t)CONFIG_BOARD));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_SDK_VERSION_STRING_ENABLE
+bi_decl(bi_string(BINARY_INFO_TAG_RASPBERRY_PI, BINARY_INFO_ID_RP_SDK_VERSION,
+		  (uint32_t)"zephyr-" STRINGIFY(BUILD_VERSION)));
+#endif
+
+#if defined(CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_VERSION_STRING_ENABLE) && defined(HAS_APP_VERSION)
+bi_decl(bi_program_version_string((uint32_t)APP_VERSION_EXTENDED_STRING));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_DESCRIPTION_ENABLE
+bi_decl(bi_program_description((uint32_t)BI_PROGRAM_DESCRIPTION));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_URL_ENABLE
+bi_decl(bi_program_url((uint32_t)BI_PROGRAM_URL));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PROGRAM_BUILD_DATE_ENABLE
+bi_decl(bi_program_build_date_string((uint32_t)BI_PROGRAM_BUILD_DATE));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_BOOT_STAGE2_NAME_ENABLE
+bi_decl(bi_string(BINARY_INFO_TAG_RASPBERRY_PI, BINARY_INFO_ID_RP_BOOT2_NAME,
+		  (uint32_t)PICO_BOOT_STAGE2_NAME));
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_ATTRIBUTE_BUILD_TYPE_ENABLE
+#ifdef CONFIG_DEBUG
+bi_decl(bi_program_build_attribute((uint32_t)"Debug"));
+#else
+bi_decl(bi_program_build_attribute((uint32_t)"Release"));
+#endif
+#endif
+
+#ifdef CONFIG_RPI_PICO_BINARY_INFO_PINS_WITH_FUNC_ENABLE
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 0
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 0);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 1
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 1);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 2
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 2);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 3
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 3);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 4
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 4);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 5
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 5);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 6
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 6);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 7
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 7);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 8
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 8);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 9
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 9);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 10
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 10);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 11
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 11);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 12
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 12);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 13
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 13);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 14
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 14);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 15
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 15);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 16
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 16);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 17
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 17);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 18
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 18);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 19
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 19);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 20
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 20);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 21
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 21);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 22
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 22);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 23
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 23);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 24
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 24);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 25
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 25);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 26
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 26);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 27
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 27);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 28
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 28);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 29
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 29);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 30
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 30);
+#endif
+#if DT_CHILD_NUM(DT_NODELABEL(pinctrl)) > 31
+BI_PINS_FROM_PINCTRL_GROUP(DT_NODELABEL(pinctrl), 31);
+#endif
+#endif

--- a/soc/raspberrypi/rpi_pico/common/binary_info.c
+++ b/soc/raspberrypi/rpi_pico/common/binary_info.c
@@ -43,8 +43,13 @@
 #define PINCTRL_OFFSET_IF_PRECEDES(child, target)                                                   \
         ((DT_NODE_CHILD_IDX(child) < DT_NODE_CHILD_IDX(target)) ? PINCTRL_GROUP_PIN_COUNT(child) : 0)
 #define PINCTRL_GROUP_OFFSET(parent, child)                                                         \
-        (0 DT_FOREACH_CHILD_SEP_VARGS(parent, PINCTRL_OFFSET_IF_PRECEDES, (+), child))
-#define PINCTRL_TOTAL_PINS(node_id) (0 DT_FOREACH_CHILD_SEP(node_id, PINCTRL_GROUP_PIN_COUNT, (+)))
+        (COND_CODE_0(DT_CHILD_NUM(parent),                                                        \
+                     (0),                                                                         \
+                     (DT_FOREACH_CHILD_SEP_VARGS(parent, PINCTRL_OFFSET_IF_PRECEDES, (+), child))))
+#define PINCTRL_TOTAL_PINS(node_id)                                                                 \
+        (COND_CODE_0(DT_CHILD_NUM(node_id),                                                        \
+                     (0),                                                                         \
+                     (DT_FOREACH_CHILD_SEP(node_id, PINCTRL_GROUP_PIN_COUNT, (+)))))
 
 /* Iterate groups and subgroups */
 

--- a/soc/raspberrypi/rpi_pico/common/binary_info.ld
+++ b/soc/raspberrypi/rpi_pico/common/binary_info.ld
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = ALIGN(4);
+__binary_info_start = .;
+KEEP(*(.binary_info.keep.*))
+*(.binary_info.*)
+__binary_info_end = .;

--- a/soc/raspberrypi/rpi_pico/common/binary_info_header.S
+++ b/soc/raspberrypi/rpi_pico/common/binary_info_header.S
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pico/binary_info/defs.h"
+
+.section .binary_info_header
+
+/* binary_info_header */
+binary_info_header:
+.word BINARY_INFO_MARKER_START
+.word __binary_info_start
+.word __binary_info_end
+.word data_cpy_table /* we may need to decode pointers that are in RAM at runtime.*/
+.word BINARY_INFO_MARKER_END
+
+.align 2
+
+/* data_cpy_table */
+data_cpy_table:
+.word 0 /* centinel */

--- a/soc/raspberrypi/rpi_pico/common/binary_info_header.ld
+++ b/soc/raspberrypi/rpi_pico/common/binary_info_header.ld
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP (*(.binary_info_header))


### PR DESCRIPTION
## Summary
- compute pinctrl group offsets using DT_FOREACH_CHILD helpers instead of DT_CHILD_BY_IDX
- generate binary info declarations for each pinctrl child via DT_FOREACH_CHILD rather than manual index guards

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c77aca348322a25c272c7a813431