### PR TITLE
boards: Add `zephyr::board` directive on top of documents

### DIFF
--- a/boards/96boards/aerocore2/doc/index.rst
+++ b/boards/96boards/aerocore2/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_aerocore2_board:
+.. zephyr:board:: 96b_aerocore2
 
 96Boards Aerocore2
 ##################

--- a/boards/96boards/argonkey/doc/index.rst
+++ b/boards/96boards/argonkey/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_argonkey:
+.. zephyr:board:: 96b_argonkey
 
 96Boards Argonkey
 #################

--- a/boards/96boards/avenger96/doc/index.rst
+++ b/boards/96boards/avenger96/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_avenger96:
+.. zephyr:board:: 96b_avenger96
 
 96Boards Avenger96
 ##################

--- a/boards/96boards/neonkey/doc/index.rst
+++ b/boards/96boards/neonkey/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_neonkey:
+.. zephyr:board:: 96b_neonkey
 
 96Boards Neonkey
 ################

--- a/boards/96boards/nitrogen/doc/index.rst
+++ b/boards/96boards/nitrogen/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_nitrogen_board:
+.. zephyr:board:: 96b_nitrogen
 
 96Boards Nitrogen
 #################

--- a/boards/96boards/stm32_sensor_mez/doc/index.rst
+++ b/boards/96boards/stm32_sensor_mez/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_stm32_sensor_mez:
+.. zephyr:board:: 96b_stm32_sensor_mez
 
 96Boards STM32 Sensor Mezzanine
 ###############################

--- a/boards/acrn/acrn/doc/index.rst
+++ b/boards/acrn/acrn/doc/index.rst
@@ -1,3 +1,5 @@
+.. zephyr:board:: acrn
+
 ACRN hypervisor
 ###############
 

--- a/boards/brcm/bcm958401m2/doc/index.rst
+++ b/boards/brcm/bcm958401m2/doc/index.rst
@@ -1,4 +1,4 @@
-.. _bcm958401m2:
+.. zephyr:board:: bcm958401m2
 
 Broadcom BCM958401M2
 ####################

--- a/boards/circuitdojo/feather/doc/index.rst
+++ b/boards/circuitdojo/feather/doc/index.rst
@@ -1,4 +1,4 @@
-.. _circuitdojo_feather_nrf9160:
+.. zephyr:board:: circuitdojo_feather
 
 nRF9160 Feather
 ###############

--- a/boards/digilent/arty_a7/doc/index.rst
+++ b/boards/digilent/arty_a7/doc/index.rst
@@ -1,4 +1,4 @@
-.. _arty:
+.. zephyr:board:: arty_a7
 
 Digilent Arty
 #############

--- a/boards/digilent/zybo/doc/index.rst
+++ b/boards/digilent/zybo/doc/index.rst
@@ -1,4 +1,4 @@
-.. _zybo:
+.. zephyr:board:: zybo
 
 Digilent Zybo
 #############

--- a/boards/fanke/fk7b0m1_vbt6/doc/index.rst
+++ b/boards/fanke/fk7b0m1_vbt6/doc/index.rst
@@ -1,4 +1,4 @@
-.. _fk7b0m1_vbt6:
+.. zephyr:board:: fk7b0m1_vbt6
 
 FANKE FK7B0M1-VBT6
 ##################

--- a/boards/intel/adl/doc/index.rst
+++ b/boards/intel/adl/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_adl_n:
+.. zephyr:board:: intel_adl_crb
 
 Alder Lake N
 ############

--- a/boards/intel/adsp/doc/index.rst
+++ b/boards/intel/adsp/doc/index.rst
@@ -1,4 +1,4 @@
-.. _boards-intel-adsp:
+.. zephyr:board:: intel_adsp
 
 Intel ADSP
 ##########

--- a/boards/intel/ehl/doc/index.rst
+++ b/boards/intel/ehl/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_ehl_crb:
+.. zephyr:board:: intel_ehl_crb
 
 Elkhart Lake CRB
 ################

--- a/boards/intel/ish/doc/index.rst
+++ b/boards/intel/ish/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_ish:
+.. zephyr:board:: intel_ish_5_4_1
 
 Intel Integrated Sensor Hub (ISH)
 #################################

--- a/boards/intel/niosv_g/doc/index.rst
+++ b/boards/intel/niosv_g/doc/index.rst
@@ -1,4 +1,4 @@
-.. _niosv_g:
+.. zephyr:board:: niosv_g
 
 INTEL FPGA niosv_g
 ####################

--- a/boards/intel/niosv_m/doc/index.rst
+++ b/boards/intel/niosv_m/doc/index.rst
@@ -1,4 +1,4 @@
-.. _niosv_m:
+.. zephyr:board:: niosv_m
 
 INTEL FPGA niosv_m
 ####################

--- a/boards/intel/rpl/doc/index.rst
+++ b/boards/intel/rpl/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_rpl_crb:
+.. zephyr:board:: intel_rpl_p_crb
 
 Raptor Lake CRB
 ###############

--- a/boards/intel/socfpga/agilex5_socdk/doc/index.rst
+++ b/boards/intel/socfpga/agilex5_socdk/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_socfpga_agilex5_socdk:
+.. zephyr:board:: intel_socfpga_agilex5_socdk
 
 Intel® Agilex™ 5 SoC FPGA Development Kit
 #########################################

--- a/boards/intel/socfpga/agilex_socdk/doc/index.rst
+++ b/boards/intel/socfpga/agilex_socdk/doc/index.rst
@@ -1,4 +1,4 @@
-.. _intel_socfpga_agilex_socdk:
+.. zephyr:board:: intel_socfpga_agilex_socdk
 
 Intel Agilex SoC Development Kit
 #################################

--- a/boards/intel/socfpga_std/cyclonev_socdk/doc/index.rst
+++ b/boards/intel/socfpga_std/cyclonev_socdk/doc/index.rst
@@ -1,4 +1,4 @@
-.. _cyclonev_socdk:
+.. zephyr:board:: cyclonev_socdk
 
 Intel® Cyclone® V SoC Development Kit
 #####################################

--- a/boards/mikroe/hexiwear/doc/index.rst
+++ b/boards/mikroe/hexiwear/doc/index.rst
@@ -1,4 +1,4 @@
-.. _hexiwear:
+.. zephyr:board:: hexiwear
 
 Hexiwear
 ########

--- a/boards/nordic/nrf9160dk/doc/index.rst
+++ b/boards/nordic/nrf9160dk/doc/index.rst
@@ -1,4 +1,4 @@
-.. _nrf9160dk_nrf9160:
+.. zephyr:board:: nrf9160dk
 
 nRF9160 DK
 ##########

--- a/boards/phytec/phyboard_electra/doc/index.rst
+++ b/boards/phytec/phyboard_electra/doc/index.rst
@@ -1,4 +1,4 @@
-.. _phyboard_electra_am64xx_m4:
+.. zephyr:board:: phyboard_electra
 
 phyBOARD-Electra AM64x M4F Core
 ###############################

--- a/boards/phytec/phyboard_nash/doc/index.rst
+++ b/boards/phytec/phyboard_nash/doc/index.rst
@@ -1,4 +1,4 @@
-.. _phyboard_nash:
+.. zephyr:board:: phyboard_nash
 
 phyBOARD-Nash i.MX93
 ####################

--- a/boards/phytec/phyboard_polis/doc/index.rst
+++ b/boards/phytec/phyboard_polis/doc/index.rst
@@ -1,4 +1,4 @@
-.. _phyboard_polis:
+.. zephyr:board:: phyboard_polis
 
 phyBOARD-Polis i.MX8M Mini
 ##########################

--- a/boards/phytec/phyboard_pollux/doc/index.rst
+++ b/boards/phytec/phyboard_pollux/doc/index.rst
@@ -1,4 +1,4 @@
-.. _phyboard_pollux:
+.. zephyr:board:: phyboard_pollux
 
 phyBOARD-Pollux i.MX8M Plus
 ###########################

--- a/boards/phytec/reel_board/doc/index.rst
+++ b/boards/phytec/reel_board/doc/index.rst
@@ -1,4 +1,4 @@
-.. _reel_board:
+.. zephyr:board:: reel_board
 
 reel board
 ##########

--- a/boards/pjrc/teensy4/doc/index.rst
+++ b/boards/pjrc/teensy4/doc/index.rst
@@ -1,4 +1,4 @@
-.. _teensy40:
+.. zephyr:board:: teensy40
 
 PJRC TEENSY 4
 #############

--- a/boards/sparkfun/micromod/doc/index.rst
+++ b/boards/sparkfun/micromod/doc/index.rst
@@ -1,4 +1,4 @@
-.. _sparkfun_micromod:
+.. zephyr:board:: micromod
 
 SparkFun MicroMod board Processor
 #################################

--- a/boards/sparkfun/red_v_things_plus/doc/index.rst
+++ b/boards/sparkfun/red_v_things_plus/doc/index.rst
@@ -1,4 +1,4 @@
-.. _sparkfun_red_v_things_plus:
+.. zephyr:board:: sparkfun_red_v_things_plus
 
 SparkFun RED-V Things Plus
 ##########################

--- a/boards/sparkfun/thing_plus/doc/index.rst
+++ b/boards/sparkfun/thing_plus/doc/index.rst
@@ -1,4 +1,4 @@
-.. _sparkfun_thing_plus_nrf9160:
+.. zephyr:board:: sparkfun_thing_plus
 
 nRF9160 Thing Plus
 ##################

--- a/boards/u-blox/ubx_bmd300eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd300eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd300eval_nrf52832:
+.. zephyr:board:: ubx_bmd300eval
 
 u-blox EVK-BMD-30/35: BMD-300-EVAL, BMD-301-EVAL, and BMD-350-EVAL
 ##################################################################

--- a/boards/u-blox/ubx_bmd330eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd330eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd330eval_nrf52810:
+.. zephyr:board:: ubx_bmd330eval
 
 u-blox EVK-BMD-330: BMD-330-EVAL
 ################################

--- a/boards/u-blox/ubx_bmd340eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd340eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd340eval_nrf52840:
+.. zephyr:board:: ubx_bmd340eval
 
 u-blox EVK-BMD-34/38: BMD-340-EVAL and BMD-341-EVAL
 ###################################################

--- a/boards/u-blox/ubx_bmd345eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd345eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd345eval_nrf52840:
+.. zephyr:board:: ubx_bmd345eval
 
 u-blox EVK-BMD-34/38: BMD-345-EVAL
 ##################################

--- a/boards/u-blox/ubx_bmd360eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd360eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd360eval_nrf52811:
+.. zephyr:board:: ubx_bmd360eval
 
 u-blox EVK-BMD-360: BMD-360-EVAL
 ################################

--- a/boards/u-blox/ubx_bmd380eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd380eval/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_bmd380eval_nrf52840:
+.. zephyr:board:: ubx_bmd380eval
 
 u-blox EVK-BMD-34/48: BMD-380-EVAL
 ##################################

--- a/boards/u-blox/ubx_evkannab1/doc/index.rst
+++ b/boards/u-blox/ubx_evkannab1/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_evkannab1_nrf52832:
+.. zephyr:board:: ubx_evkannab1
 
 u-blox EVK-ANNA-B11x
 ####################

--- a/boards/u-blox/ubx_evkninab1/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab1/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_evkninab1_nrf52832:
+.. zephyr:board:: ubx_evkninab1
 
 u-blox EVK NINA-B11x
 ####################

--- a/boards/u-blox/ubx_evkninab3/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab3/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_ninab3_nrf52840:
+.. zephyr:board:: ubx_evkninab3
 
 u-blox EVK-NINA-B3
 ##################

--- a/boards/u-blox/ubx_evkninab4/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab4/doc/index.rst
@@ -1,4 +1,4 @@
-.. _ubx_ninab4_nrf52833:
+.. zephyr:board:: ubx_evkninab4
 
 u-blox EVK NINA-B40x
 ####################

--- a/boards/xen/xenvm/doc/index.rst
+++ b/boards/xen/xenvm/doc/index.rst
@@ -1,4 +1,4 @@
-.. xenvm:
+.. zephyr:board:: xenvm
 
 ARMv8 Xen Virtual Machine Example
 #################################


### PR DESCRIPTION
Update documents to add missing zephyr::board directive.